### PR TITLE
PNG image support via patterns

### DIFF
--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -230,9 +230,9 @@ typedef struct NSVGSymbol
 } NSVGSymbol;
 
 // Parses SVG file from a file, returns SVG image as paths.
-NSVGimage* nsvgParseFromFile(const char* filename, const char* units, float dpi);
+NSVGimage* nsvgParseFromFile(const char* filename, const char* dir, const char* units, float dpi);
 
-NSVGimage* nsvgParseFromFileWithCSS(const char* filename, const char* styleCSS, const char* units, float dpi);
+NSVGimage* nsvgParseFromFileWithCSS(const char* filename, const char* dir, const char* styleCSS, const char* units, float dpi);
 
 // Parses SVG file from a null terminated string, returns SVG image as paths.
 // Important note: changes the string.
@@ -1349,7 +1349,6 @@ static float nsvg__convertToPixels(NSVGparser* p, NSVGcoordinate c, float orig, 
 		case NSVG_UNITS_PERCENT:	return orig + c.value / 100.0f * length;
 		default:					return c.value;
 	}
-	return c.value;
 }
 
 static NSVGgradientData* nsvg__findGradientData(NSVGparser* p, const char* id)
@@ -4646,7 +4645,7 @@ static void parsePattern(NSVGparser* p, const char** dict)
 {
 	NSVGattrib* attr = nsvg__getAttr(p);
 	int i;
-	float w, h;
+	float w = 0, h = 0;
 	NSVGpattern *pt;
 
 	for (i = 0; dict[i]; i += 2) {

--- a/src/nanosvg.h
+++ b/src/nanosvg.h
@@ -75,7 +75,8 @@ enum NSVGpaintType {
 	NSVG_PAINT_NONE = 0,
 	NSVG_PAINT_COLOR = 1,
 	NSVG_PAINT_LINEAR_GRADIENT = 2,
-	NSVG_PAINT_RADIAL_GRADIENT = 3
+	NSVG_PAINT_RADIAL_GRADIENT = 3,
+	NSVG_PAINT_PATTERN = 4
 };
 
 enum NSVGspreadType {
@@ -166,6 +167,7 @@ typedef struct NSVGshape
 	char fillRule;				// Fill rule, see NSVGfillRule.
 	unsigned char flags;		// Logical or of NSVG_FLAGS_* flags
 	float bounds[4];			// Tight bounding box of the shape [minx,miny,maxx,maxy].
+	float xform[6];
     char preserveSpace;
     float deltaTextLocation[2];
 	char text[256];
@@ -261,9 +263,12 @@ void nsvgDeleteShape(NSVGshape* shape);
 #include <regex>
 #include <string>
 
+#include <png.h>
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
+
+#include "nanosvgeg.h"
 
 #define NSVG_PI (3.14159265358979323846264338327f)
 #define NSVG_KAPPA90 (0.5522847493f)	// Length proportional to radius of a cubic bezier handle for 90deg arcs.
@@ -602,6 +607,15 @@ typedef struct NSVGattribData
   struct NSVGattribData* next;
 } NSVGattribData;
 
+typedef struct NSVGpattern {
+  char id[64];
+  int nx, ny;  //repeat
+  float width;
+  float height;
+  void* image;
+  struct NSVGpattern* next;
+} NSVGpattern;
+
 typedef struct NSVGgroup
 {
   float accumulateXform[6];
@@ -656,8 +670,10 @@ typedef struct NSVGparser
 	NSVGshape* currentClippingPath;
     NSVGViewbox viewbox;
     NSVGAlignMent alignment;
+	NSVGpattern *patterns;
 	float dpi;
 	const char* units;
+	const char* dir;
 	char pathFlag;
 	char clipPathFlag;
 	char defsFlag;
@@ -667,6 +683,7 @@ typedef struct NSVGparser
 	char symbolFlag;
 	char textFlag;
 	char textSpanFlag;
+	char patternFlag;
 } NSVGparser;
 
 static void nsvg__xformIdentity(float* t)
@@ -1801,6 +1818,7 @@ static NSVGshape* nsvg__addShape(NSVGparser* p)
 	shape->miterLimit = attr->miterLimit;
 	shape->fillRule = attr->fillRule;
 	shape->opacity = attr->opacity;
+	memcpy(shape->xform, attr->xform, sizeof(float) * 6);
 	yScale = nsvg__getYScale(group->accumulateXform, attr->xform);
 	xScale = nsvg__getXScale(group->accumulateXform, attr->xform);
 	shape->fontSize = attr->fontSize * yScale;
@@ -1887,6 +1905,17 @@ static NSVGshape* nsvg__addShape(NSVGparser* p)
 		if (shape->fill.gradient == NULL) {
 			shape->fill.type = NSVG_PAINT_NONE;
 		}
+	} else if (attr->hasFill == 3) {
+		shape->fill.type = NSVG_PAINT_PATTERN;
+		const char *id = attr->fillGradient;
+		NSVGpattern* pt = p->patterns;
+		while (pt) {
+			if (strcmp(pt->id, id) == 0) {
+				break;
+			}
+			pt = pt->next;
+		}
+		shape->fill.gradient = (NSVGgradient*)pt;
 	}
 
 	// Set stroke
@@ -1903,6 +1932,17 @@ static NSVGshape* nsvg__addShape(NSVGparser* p)
 		shape->stroke.gradient = nsvg__createGradient(p, attr->strokeGradient, localBounds, &shape->stroke.type);
 		if (shape->stroke.gradient == NULL)
 			shape->stroke.type = NSVG_PAINT_NONE;
+	} else if (attr->hasStroke == 3) {
+		shape->stroke.type = NSVG_PAINT_PATTERN;
+		const char *id = attr->strokeGradient;
+		NSVGpattern* pt = p->patterns;
+		while (pt) {
+			if (strcmp(pt->id, id) == 0) {
+				break;
+			}
+			pt = pt->next;
+		}
+		shape->stroke.gradient = (NSVGgradient*)pt;
 	}
 
 	// Set flags
@@ -2105,7 +2145,7 @@ error:
 }
 
 // We roll our own string to float because the std library one uses locale and messes things up.
-static double nsvg__atof(const char* s)
+static float nsvg__atof(const char* s)
 {
 	char* cur = (char*)s;
 	char* end = NULL;
@@ -2160,7 +2200,7 @@ static double nsvg__atof(const char* s)
 		}
 	}
 
-	return res * sign;
+	return (float)(res * sign);
 }
 
 
@@ -2734,7 +2774,11 @@ static int nsvg__parseAttr(NSVGparser* p, const char* name, const char* value)
 		if (strcmp(value, "none") == 0) {
 			attr->hasFill = 0;
 		} else if (strncmp(value, "url(", 4) == 0) {
-			attr->hasFill = 2;
+			if (strstr(value, "pattern")) {
+				attr->hasFill = 3;
+			} else {
+				attr->hasFill = 2;
+			}
 			nsvg__parseUrl(attr->fillGradient, value);
 		} else {
 			attr->hasFill = 1;
@@ -2748,7 +2792,11 @@ static int nsvg__parseAttr(NSVGparser* p, const char* name, const char* value)
 		if (strcmp(value, "none") == 0) {
 			attr->hasStroke = 0;
 		} else if (strncmp(value, "url(", 4) == 0) {
-			attr->hasStroke = 2;
+			if (strstr(value, "pattern")) {
+				attr->hasStroke = 3;
+			} else {
+				attr->hasStroke = 2;
+			}
 			nsvg__parseUrl(attr->strokeGradient, value);
 		} else {
 			attr->hasStroke = 1;
@@ -3847,6 +3895,7 @@ static void nsvg__parseSymbol(NSVGparser* p, const char** attr)
     }
 }
 
+/* Slice - I dont know what it should be
 static void nsvg__parseImage(NSVGparser* p, const char** attr)
 {
 	float x = 0.0f;
@@ -3961,6 +4010,7 @@ static void nsvg__parseImage(NSVGparser* p, const char** attr)
         }
 	}
 }
+*/
 
 static void nsvg__imageBounds(NSVGparser* p, float* bounds)
 {
@@ -4535,6 +4585,88 @@ static void nsvg__parsePoly(NSVGparser* p, const char** attr, int closeFlag)
 	nsvg__addShape(p);
 }
 
+static void parseImage(NSVGparser* p, const char** dict)
+{
+	NSVGpattern *pt = NULL;
+	int i;
+	float w, h;
+	const char *href = NULL;
+	EG_IMAGE *NewImage = NULL;
+
+	for (i = 0; dict[i]; i += 2) {
+		if (strcmp(dict[i], "width") == 0) {
+			w = nsvg__parseCoordinate(p, dict[i + 1], 0.0f, nsvg__actualWidth(p));
+		} else if (strcmp(dict[i], "height") == 0) {
+			h = nsvg__parseCoordinate(p, dict[i + 1], 0.0f, nsvg__actualHeight(p));
+		} else if (strcmp(dict[i], "xlink:href") == 0) {
+			href = dict[i + 1];
+		} else {
+			nsvg__parseAttr(p, dict[i], dict[i + 1]);
+		}
+	}
+	if (!href) {
+		return;
+	}
+	if (p->patternFlag) {
+		pt = p->patterns; //the last one
+	}
+
+	{
+		char path[FILENAME_MAX + 1];
+		strcpy_s(path, sizeof(path), p->dir);
+		strcat_s(path, sizeof(path), "\\");
+		strcat_s(path, sizeof(path), (char*)href);
+
+		png_image image;
+		memset(&image, 0, sizeof(image));
+		image.version = PNG_IMAGE_VERSION;
+		if (png_image_begin_read_from_file(&image, path) == 0)
+			return;
+		image.format = PNG_FORMAT_RGBA;
+
+		png_bytep buffer;
+		size_t image_size = PNG_IMAGE_SIZE(image);
+		buffer = (png_bytep)malloc(image_size);
+		if (buffer == NULL)
+			return;
+
+		if (png_image_finish_read(&image, NULL, buffer, 0, NULL) == 0)
+			return;
+
+		NewImage = new EG_IMAGE;
+		NewImage->Width = image.width;
+		NewImage->Height = image.height;
+		NewImage->HasAlpha = true;
+		NewImage->PixelData = (EG_PIXEL*)buffer;
+	}
+	pt->image = (void *)NewImage;
+}
+
+static void parsePattern(NSVGparser* p, const char** dict)
+{
+	NSVGattrib* attr = nsvg__getAttr(p);
+	int i;
+	float w, h;
+	NSVGpattern *pt;
+
+	for (i = 0; dict[i]; i += 2) {
+		if (strcmp(dict[i], "width") == 0) {
+			w = nsvg__parseCoordinate(p, dict[i + 1], 0.0f, nsvg__actualWidth(p));
+		} else if (strcmp(dict[i], "height") == 0) {
+			h = nsvg__parseCoordinate(p, dict[i + 1], 0.0f, nsvg__actualHeight(p));
+		} else {
+			nsvg__parseAttr(p, dict[i], dict[i + 1]);
+		}
+	}
+
+	pt = (NSVGpattern*)malloc(sizeof(NSVGpattern));
+	strncpy_s(pt->id, 64, attr->id, 64);
+	pt->width = w;
+	pt->height = h;
+	pt->next = p->patterns;
+	p->patterns = pt;
+}
+
 static void nsvg__parseSVG(NSVGparser* p, const char** attr)
 {
     p->alignment.alignType = NSVG_ALIGN_MEET; //default aligntype is meet
@@ -4829,9 +4961,13 @@ static void nsvg__startElement(void* ud, const char* el, const char** attr)
 		nsvg__parseUse(p, attr);
 		p->useFlag = 0;
 	} else if (strcmp(el, "image") == 0) {
-		nsvg__pushAttr(p);
-		nsvg__parseImage(p, attr);
-		nsvg__popAttr(p);
+		// nsvg__pushAttr(p);
+		// nsvg__parseIMAGE(p, attr);
+		parseImage(p, attr);
+		// nsvg__popAttr(p);
+	} else if (strcmp(el, "pattern") == 0) {
+		parsePattern(p, attr);
+		p->patternFlag = 1;
 	} else if (strcmp(el, "symbol") == 0) {
 		nsvg__pushAttr(p);
 		p->symbolFlag = 1;
@@ -5053,6 +5189,8 @@ static void nsvg__endElement(void* ud, const char* el)
 		p->pathFlag = 0;
 	} else if (strcmp(el, "defs") == 0) {
 		p->defsFlag = NSVG_DEFFLAGS_NONE;
+	} else if (strcmp(el, "pattern") == 0) {
+		p->patternFlag = 0;
 	} else if (strcmp(el, "style") == 0) {
 		p->styleFlag = 0;
 	} else if (strcmp(el, "text") == 0) {
@@ -5089,7 +5227,7 @@ void nsvgKeepClipPathsInside(NSVGparser* p)
   }
 }
 
-NSVGimage* nsvgParse(char* input, const char* styleCSS, const char* units, float dpi)
+NSVGimage* nsvgParse(char* input, const char* dir, const char* styleCSS, const char* units, float dpi)
 {
 	NSVGparser* p;
 	NSVGimage* ret = 0;
@@ -5100,6 +5238,7 @@ NSVGimage* nsvgParse(char* input, const char* styleCSS, const char* units, float
 	}
 	p->dpi = dpi;
 	p->units = units;
+	p->dir = dir;
 
 	nsvg__parseCSS(p, styleCSS);
 	nsvg__parseXML(input, nsvg__startElement, nsvg__endElement, nsvg__content, nsvg__parseEntityStyle, p);
@@ -5117,7 +5256,7 @@ NSVGimage* nsvgParse(char* input, const char* styleCSS, const char* units, float
 	return ret;
 }
 
-NSVGimage* nsvgParseFromFileWithCSS(const char* filename, const char* styleCSS, const char* units, float dpi)
+NSVGimage* nsvgParseFromFileWithCSS(const char* filename, const char* dir, const char* styleCSS, const char* units, float dpi)
 {
 	FILE* fp = NULL;
 	size_t size;
@@ -5134,7 +5273,7 @@ NSVGimage* nsvgParseFromFileWithCSS(const char* filename, const char* styleCSS, 
 	if (fread(data, 1, size, fp) != size) goto error;
 	data[size] = '\0';	// Must be null terminated.
 	fclose(fp);
-	image = nsvgParse(data, styleCSS, units, dpi);
+	image = nsvgParse(data, dir, styleCSS, units, dpi);
 	free(data);
 
 	return image;
@@ -5146,9 +5285,9 @@ error:
 	return NULL;
 }
 
-NSVGimage* nsvgParseFromFile(const char* filename, const char* units, float dpi)
+NSVGimage* nsvgParseFromFile(const char* filename, const char* dir, const char* units, float dpi)
 {
-  return nsvgParseFromFileWithCSS(filename, "", units, dpi);
+  return nsvgParseFromFileWithCSS(filename, dir, "", units, dpi);
 }
 
 NSVGpath* nsvgDuplicatePath(NSVGpath* p)

--- a/src/nanosvgeg.h
+++ b/src/nanosvgeg.h
@@ -1,0 +1,15 @@
+#ifndef NANOSVGEG_H
+#define NANOSVGEG_H
+
+typedef struct {
+	unsigned char r, g, b, a;
+} EG_PIXEL;
+
+typedef struct {
+	int	Width;
+	int	Height;
+	EG_PIXEL *PixelData;
+	bool	HasAlpha;
+} EG_IMAGE;
+
+#endif

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -1174,7 +1174,7 @@ static void nsvg__scanlineSolid(unsigned char* dst, int count, unsigned char* co
 static void nsvg__rasterizeSortedEdges(NSVGrasterizer *r, float tx, float ty, float scale, NSVGcachedPaint* cache, char fillRule)
 {
 	NSVGactiveEdge *active = NULL;
-	int y, s;
+	size_t y, s;
 	int e = 0;
 	int maxWeight = (255 / NSVG__SUBSAMPLES);  // weight per vertical scanline
 	int xmin, xmax;
@@ -1253,7 +1253,7 @@ static void nsvg__rasterizeSortedEdges(NSVGrasterizer *r, float tx, float ty, fl
 		if (xmin < 0) xmin = 0;
 		if (xmax > r->width-1) xmax = r->width-1;
 		if (xmin <= xmax) {
-			nsvg__scanlineSolid(&r->bitmap[y * r->stride] + xmin*4, xmax-xmin+1, &r->scanline[xmin], xmin, y, tx,ty, scale, cache);
+			nsvg__scanlineSolid(&r->bitmap[y * r->stride] + xmin*4, xmax-xmin+1, &r->scanline[xmin], xmin, (int)y, tx,ty, scale, cache);
 		}
 	}
 
@@ -1261,7 +1261,7 @@ static void nsvg__rasterizeSortedEdges(NSVGrasterizer *r, float tx, float ty, fl
 
 static void nsvg__unpremultiplyAlpha(unsigned char* image, int w, int h, int stride)
 {
-	int x,y;
+	size_t x,y;
 
 	// Unpremultiply
 	for (y = 0; y < h; y++) {
@@ -1445,7 +1445,7 @@ void nsvgRasterize(NSVGrasterizer* r,
 	float xform[6];
 	NSVGedge *e = NULL;
 	NSVGcachedPaint cache;
-	int i;
+	size_t i;
 	float scalex = scale; // TODO
 	float scaley = scale; //
 

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -78,6 +78,8 @@ void nsvgDeleteRasterizer(NSVGrasterizer*);
 
 #include <math.h>
 
+#include "nanosvgeg.h"
+
 #define NSVG__SUBSAMPLES	5
 #define NSVG__FIXSHIFT		10
 #define NSVG__FIX			(1 << NSVG__FIXSHIFT)
@@ -114,7 +116,9 @@ typedef struct NSVGmemPage {
 typedef struct NSVGcachedPaint {
 	char type;
 	char spread;
+	char pad[6];
 	float xform[6];
+	void *image;
 	unsigned int colors[256];
 } NSVGcachedPaint;
 
@@ -1109,6 +1113,61 @@ static void nsvg__scanlineSolid(unsigned char* dst, int count, unsigned char* co
 			dst += 4;
 			fx += dx;
 		}
+	} else if (cache->type == NSVG_PAINT_PATTERN) {
+		float fx, fy, dx, gx, gy;
+		float* t = cache->xform;
+		EG_IMAGE *Pattern = (EG_IMAGE *)cache->image;
+		if (!Pattern) {
+			return;
+		}
+		int Width = Pattern->Width;
+		int Height = Pattern->Height;
+
+		int i, cr, cg, cb, ca, ix, iy;
+		int j;
+		fx = (float)x;
+		fy = (float)y;
+		dx = 1.0f;
+
+		//    unsigned int c;
+		for (i = 0; i < count; i++) {
+		  int r, g, b, a, ia;
+		  gx = fx * t[0] + fy * t[2] + t[4];
+		  gy = fx * t[1] + fy * t[3] + t[5];
+		  ix = (int)(gx * Width) % Width;
+		  iy = (int)(gy * Height) % Height;
+
+		  j = iy * Width + ix;
+		  if (j < 0)
+			continue;
+
+		  cr = Pattern->PixelData[j].r;
+		  cb = Pattern->PixelData[j].b;
+		  cg = Pattern->PixelData[j].g;
+		  ca = Pattern->PixelData[j].a;
+		  a = nsvg__div255((int)cover[0] * ca);
+		  ia = 255 - a;
+
+		  // Premultiply
+		  r = nsvg__div255(cr * a);
+		  g = nsvg__div255(cg * a);
+		  b = nsvg__div255(cb * a);
+
+		  // Blend over
+		  r += nsvg__div255(ia * (int)dst[0]);
+		  g += nsvg__div255(ia * (int)dst[1]);
+		  b += nsvg__div255(ia * (int)dst[2]);
+		  a += nsvg__div255(ia * (int)dst[3]);
+
+		  dst[0] = (unsigned char)r;
+		  dst[1] = (unsigned char)g;
+		  dst[2] = (unsigned char)b;
+		  dst[3] = (unsigned char)a;
+
+		  cover++;
+		  dst += 4;
+		  fx += dx;
+		}
 	}
 }
 
@@ -1260,7 +1319,7 @@ static void nsvg__unpremultiplyAlpha(unsigned char* image, int w, int h, int str
 }
 
 
-static void nsvg__initPaint(NSVGcachedPaint* cache, NSVGpaint* paint, float opacity)
+static void nsvg__initPaint(NSVGcachedPaint* cache, NSVGpaint* paint, NSVGshape* shape, float *xformShape, float opacity)
 {
 	int i, j;
 	NSVGgradient* grad;
@@ -1273,6 +1332,22 @@ static void nsvg__initPaint(NSVGcachedPaint* cache, NSVGpaint* paint, float opac
 	}
 
 	grad = paint->gradient;
+
+	if (cache->type == NSVG_PAINT_PATTERN) {
+		cache->colors[0] = nsvg__applyOpacity(0, opacity);
+		if (grad) {
+			cache->image = ((NSVGpattern*)grad)->image;
+		}
+		float xform[6];
+		nsvg__xformIdentity(xform);
+		xform[0] = shape->bounds[2] - shape->bounds[0];
+		xform[3] = shape->bounds[3] - shape->bounds[1];
+		xform[4] = shape->bounds[0];
+		xform[5] = shape->bounds[1];
+		nsvg__xformMultiply(xform, xformShape);
+		nsvg__xformInverse(cache->xform, xform);
+		return;
+	}
 
 	cache->spread = grad->spread;
 	memcpy(cache->xform, grad->xform, sizeof(float)*6);
@@ -1367,9 +1442,14 @@ void nsvgRasterize(NSVGrasterizer* r,
 				   unsigned char* dst, int w, int h, int stride)
 {
 	NSVGshape *shape = NULL;
+	float xform[6];
 	NSVGedge *e = NULL;
 	NSVGcachedPaint cache;
 	int i;
+	float scalex = scale; // TODO
+	float scaley = scale; //
+
+	memset(&cache, 0, sizeof(NSVGcachedPaint));
 
 	r->bitmap = dst;
 	r->width = w;
@@ -1388,6 +1468,14 @@ void nsvgRasterize(NSVGrasterizer* r,
 	for (shape = image->shapes; shape != NULL; shape = shape->next) {
 		if (!(shape->flags & NSVG_FLAGS_VISIBLE))
 			continue;
+
+		memcpy(&xform[0], shape->xform, sizeof(float) * 6);
+		xform[0] *= scalex;
+		xform[1] *= scaley;
+		xform[2] *= scalex;
+		xform[3] *= scaley;
+		xform[4] = xform[4] * scalex + tx;
+		xform[5] = xform[5] * scaley + ty;
 
 		if (shape->fill.type != NSVG_PAINT_NONE) {
 			nsvg__resetPool(r);
@@ -1409,7 +1497,7 @@ void nsvgRasterize(NSVGrasterizer* r,
 			qsort(r->edges, r->nedges, sizeof(NSVGedge), nsvg__cmpEdge);
 
 			// now, traverse the scanlines and find the intersections on each scanline, use non-zero rule
-			nsvg__initPaint(&cache, &shape->fill, shape->opacity);
+			nsvg__initPaint(&cache, &shape->fill, shape, &xform[0], shape->opacity);
 
 			nsvg__rasterizeSortedEdges(r, tx,ty,scale, &cache, shape->fillRule);
 		}
@@ -1435,7 +1523,7 @@ void nsvgRasterize(NSVGrasterizer* r,
 			qsort(r->edges, r->nedges, sizeof(NSVGedge), nsvg__cmpEdge);
 
 			// now, traverse the scanlines and find the intersections on each scanline, use non-zero rule
-			nsvg__initPaint(&cache, &shape->stroke, shape->opacity);
+			nsvg__initPaint(&cache, &shape->stroke, shape, &xform[0], shape->opacity);
 
 			nsvg__rasterizeSortedEdges(r, tx,ty,scale, &cache, NSVG_FILLRULE_NONZERO);
 		}

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -1283,7 +1283,7 @@ static void nsvg__unpremultiplyAlpha(unsigned char* image, int w, int h, int str
 		for (x = 0; x < w; x++) {
 			int r = 0, g = 0, b = 0, a = row[3], n = 0;
 			if (a == 0) {
-				if (x-1 > 0 && row[-1] != 0) {
+				if (x > 1 && row[-1] != 0) {
 					r += row[-4];
 					g += row[-3];
 					b += row[-2];
@@ -1295,7 +1295,7 @@ static void nsvg__unpremultiplyAlpha(unsigned char* image, int w, int h, int str
 					b += row[6];
 					n++;
 				}
-				if (y-1 > 0 && row[-stride+3] != 0) {
+				if (y > 1 && row[-stride+3] != 0) {
 					r += row[-stride];
 					g += row[-stride+1];
 					b += row[-stride+2];


### PR DESCRIPTION
This code has been adapted from https://sourceforge.net/p/cloverefiboot/code/HEAD/tree/rEFIt_UEFI/libeg, I'm not sure how much easier would be to add a proper PNG support but this was pretty straightforward and most importantly, it works. :)

The simplest test case looks like this:

```
<?xml version="1.0" standalone="no" ?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg width="20.4853cm" height="5.42229cm" viewBox="2188.37 2966.24 512.131 135.557" xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" >
	<defs>
	<pattern width="1.0" height="1.0" id="pattern0" >
		<image xlink:href="map_smalltree_ca.png" />
	</pattern>
	</defs>
	<rect x="2364.11" y="3095.95" width="3" height="3" style="fill:url(#pattern0)" />
</svg>
```
where `map_smalltree_ca.png` is a file located in the folder specified in `nsvgParse`.

You need `libpng` installed as a dependency.